### PR TITLE
Updated Nokogiri to 1.6.0 - temporary hack of sax-machine dependency necessary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ group :development, :test do
   gem 'rake'
   gem 'guard-rspec'
   gem 'simplecov', :require => false, :platforms => :mri_19
+  # TODO Remove this dependency after updating sax-machine dependency in gemspec
+  gem 'sax-machine', github: "AutoUncle/sax-machine", ref: '95e5f8fedb5ed2d1b3b6bdf3e9ac8c3dc5750de7'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,4 @@ group :development, :test do
   gem 'rake'
   gem 'guard-rspec'
   gem 'simplecov', :require => false, :platforms => :mri_19
-  # TODO Remove this dependency after updating sax-machine dependency in gemspec
-  gem 'sax-machine', github: "AutoUncle/sax-machine", ref: '95e5f8fedb5ed2d1b3b6bdf3e9ac8c3dc5750de7'
 end

--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -19,13 +19,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
 
   s.add_dependency 'nokogiri',          '~> 1.6.0'
-  #
-  # TODO Update sax-machine dependency as soon as a new version is released with the changes of this pull request: https://github.com/pauldix/sax-machine/pull/45
-  # The current released version of sax-machine has a dependency for an older version of Nokogiri, causing compatibility issues.
-  # 
-  # Also remove temporary gem dependency in Gemfile
-  #
-  # s.add_dependency 'sax-machine',       '~> 0.2.0.rc1'
+  s.add_dependency 'sax-machine',       '~> 0.2.1'
   s.add_dependency 'curb',              '~> 0.8.1'
   s.add_dependency 'loofah',            '~> 1.2.1'
 

--- a/feedzirra.gemspec
+++ b/feedzirra.gemspec
@@ -19,7 +19,13 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
 
   s.add_dependency 'nokogiri',          '~> 1.6.0'
-  s.add_dependency 'sax-machine',       '~> 0.2.0.rc1'
+  #
+  # TODO Update sax-machine dependency as soon as a new version is released with the changes of this pull request: https://github.com/pauldix/sax-machine/pull/45
+  # The current released version of sax-machine has a dependency for an older version of Nokogiri, causing compatibility issues.
+  # 
+  # Also remove temporary gem dependency in Gemfile
+  #
+  # s.add_dependency 'sax-machine',       '~> 0.2.0.rc1'
   s.add_dependency 'curb',              '~> 0.8.1'
   s.add_dependency 'loofah',            '~> 1.2.1'
 


### PR DESCRIPTION
[sax-machine](https://github.com/pauldix/sax-machine) causes compatibility issues. This commit allows feedzirra to run Nokogiri 1.6.0 temporarily by putting the following in Gemfile:

``` ruby
gem 'sax-machine', github: 'AutoUncle/sax-machine', branch: 'nokogiri_update', ref: '95e5f8fedb5ed2d1b3b6bdf3e9ac8c3dc5750de7'
gem 'feedzirra', github: 'AutoUncle/feedzirra', branch: 'nokogiri-update', ref: '9b0bd4dd69dc52a9db58dcf51f94107fb9233dad'
```

After a new version of sax-machine is released with [this pull request](https://github.com/pauldix/sax-machine/pull/45), [Gemfile](https://github.com/AutoUncle/feedzirra/compare/nokogiri-update?expand=1#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R9) and [feedzirra.gemspec](https://github.com/AutoUncle/feedzirra/compare/nokogiri-update?expand=1#diff-6e2746e33d2df3d4e25f1802edb93b65R22) should be updated.
